### PR TITLE
chore: ignore macOS metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .devbox/
 /experiments-chat
+.DS_Store


### PR DESCRIPTION
<!-- ps-id: 16f4e260-5401-4de1-a633-9c0670ef4f70 -->